### PR TITLE
Add attempt limit

### DIFF
--- a/src/app/receiver/page.js
+++ b/src/app/receiver/page.js
@@ -23,26 +23,53 @@ export default function Receiver() {
       throw new Error("Failed to fetch IP address");
     }
   };
+  
+  const [attempts, setAttempts] = useState(0);
+  const [lastResetTime, setLastResetTime] = useState(Math.floor(Date.now() / (1000 * 60 * 2))); // Initialize to the current 2-minute interval
+
   const verifyOtp = async () => {
     try {
+      const currentTime = Math.floor(Date.now() / (1000 * 60 * 2)); // Time rounded to 2-minute intervals
+
+      // Reset attempts if a new 2-minute interval has started
+      if (currentTime !== lastResetTime) {
+        setAttempts(0);
+        setLastResetTime(currentTime);
+      }
+
+      // Check if the user has exceeded the maximum attempts
+      if (attempts >= 3) {
+        setMessage("Too many attempts. Please wait for 2 minutes and try again.");
+        return;
+      }
+
       if (inputOtp.length !== 8) {
         setMessage("Invalid input. OTP must be 8 digits long.");
         return;
       }
+
       const ipAddress = await fetchUserIp(); // Get IP address
-      const currentTime = Math.floor(Date.now() / (1000 * 60 * 2)); // Time rounded to 2-minute intervals
+
       // Validate OTP for both the current and previous time windows
       const validIntervals = [currentTime, currentTime - 1]; // Account for clock drift
       const isValid = validIntervals.some((time) => {
         const recomputedOtp = generate8DigitOtp(`${time}-${ipAddress}`).toString().padStart(8, "0");
         return recomputedOtp === inputOtp;
       });
-      setMessage(isValid ? "OTP is valid!" : "Invalid OTP. Please try again.");
+
+      if (isValid) {
+        setMessage("OTP is valid!");
+        setAttempts(0); // Reset attempts on successful validation
+      } else {
+        setAttempts((prevAttempts) => prevAttempts + 1); // Increment attempts on failure
+        setMessage("Invalid OTP. Please try again.");
+      }
     } catch (error) {
       console.error("Error validating OTP:", error);
       setMessage("Error validating OTP. Please check your input.");
     }
   };
+
 
   return (
     <div className="block">


### PR DESCRIPTION
## Description

- **Language Used**: JavaScript/React  
- **Approach Used**: Added logic to enforce an attempt limit for OTP validation using state variables and time-based checks.  
- **Question(s) Solved**: Implemented functionality to restrict the number of OTP validation attempts to three within a 2-minute window.  
- **Issue(s) Related**: N/A  

### What does this PR fix or add?  
This PR adds functionality to limit OTP validation attempts to three per 2-minute interval, ensuring a secure and user-friendly experience. The logic also resets the attempt counter after a successful OTP validation or when a new time window starts.  

### Are there any dependencies or related issues?  
No additional dependencies or related issues are introduced.  

### Any special instructions for testing?  
1. Attempt OTP validation multiple times within a 2-minute window to verify the 3-attempt limit.  
2. Ensure the attempt counter resets after 2 minutes or upon successful OTP validation.  
3. Test with invalid and valid OTPs to check proper messages and behavior.

---

## Type of Change  

- [x] New feature  

---

## Checklist  

- [x] I have tested my changes locally.  
- [ ] I have added any necessary tests.  
- [ ] I have updated the documentation (if applicable).  
- [x] I have followed the coding style of the project.  
- [x] My code is ready for review.  

---

We will review your changes and get back to you soon. Thank you for contributing to OTP-Generator!

